### PR TITLE
Refactor: remove Theme type repetition

### DIFF
--- a/packages/react/src/components/theme.tsx
+++ b/packages/react/src/components/theme.tsx
@@ -1,13 +1,8 @@
-export interface ThemeComponents {
-	button: string;
-	link: string;
-	connectedPill: string;
-	notConnectedPill: string;
-	loadingPill: string;
-	connectPill: string;
-};
+export type ThemeComponentNames = "button" | "link" | "connectedPill" | "notConnectedPill" | "loadingPill" | "connectPill"
+export type ThemeComponents = Record<ThemeComponentNames, string>
 
 const createThemeMap = <T extends {[name: string]: ThemeComponents}>(map: T): T => map;
+
 export const themeMap = createThemeMap({
 	base: {
 		button:

--- a/packages/react/src/components/theme.tsx
+++ b/packages/react/src/components/theme.tsx
@@ -1,6 +1,4 @@
-export type Theme = "base";
-
-export type ThemeComponents = {
+export interface ThemeComponents {
 	button: string;
 	link: string;
 	connectedPill: string;
@@ -9,7 +7,8 @@ export type ThemeComponents = {
 	connectPill: string;
 };
 
-export const themeMap: Record<Theme, ThemeComponents> = {
+const createThemeMap = <T extends {[name: string]: ThemeComponents}>(map: T): T => map;
+export const themeMap = createThemeMap({
 	base: {
 		button:
 			"inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 ",
@@ -23,4 +22,6 @@ export const themeMap: Record<Theme, ThemeComponents> = {
 		connectPill:
 			"inline-flex items-center shadow px-2.5 py-0.5 text-sm leading-5 font-medium rounded-full text-white bg-blue-600 hover:bg-blue-700",
 	},
-};
+});
+
+export type Theme = keyof typeof themeMap


### PR DESCRIPTION
Rather than having a literal union type for `Theme`, infer it from `themeMap`'s keys.

<img width="583" alt="image" src="https://user-images.githubusercontent.com/3943143/182059717-3a73d693-1ced-45ee-9760-2bdd8069cd99.png">
